### PR TITLE
feature/trigger_wait_no_overlap_to_trigger_again_when_reset

### DIFF
--- a/Source/GameBaseFramework/Public/Gameplay/Components/GBFTriggerManagerComponent.h
+++ b/Source/GameBaseFramework/Public/Gameplay/Components/GBFTriggerManagerComponent.h
@@ -128,6 +128,11 @@ private:
     UPROPERTY( EditAnywhere )
     uint8 bTriggerOnce : 1;
 
+    // If this is true, and TriggerOnce is true, when you call Activate to reset the trigger, it will wait for no actor
+    // to be in the box before being able to trigger again
+    UPROPERTY( EditAnywhere )
+    uint8 bWaitNoOverlapToTriggerAgainWhenReset : 1;
+
     UPROPERTY( VisibleInstanceOnly )
     uint8 bTriggered : 1;
 };


### PR DESCRIPTION
Added flag to wait for actors to leave the trigger before triggering again when Activate with reset is called