### PR TITLE
pawn_data_selector_preloading

### DIFF
--- a/Source/GameBaseFramework/Private/Engine/GBFAssetManager.cpp
+++ b/Source/GameBaseFramework/Private/Engine/GBFAssetManager.cpp
@@ -2,6 +2,7 @@
 
 #include "Characters/GBFPawnData.h"
 #include "GBFLog.h"
+#include "Characters/GBFPawnDataSelector.h"
 #include "GameplayCues/GASExtGameplayCueManager.h"
 
 #include <AbilitySystemGlobals.h>
@@ -79,6 +80,13 @@ void UGBFAssetManager::StartInitialLoading()
         "InitializeGameplayCueManager",
         [ this ]() {
             InitializeGameplayCueManager();
+        },
+        1.0f );
+
+    AddStartupJob(
+        "Load PawnData Selectors",
+        [ this ]() {
+            LoadPrimaryAssetsWithType( UGBFPawnDataSelector::GetPrimaryAssetType() );
         },
         1.0f );
 


### PR DESCRIPTION
- Pre-load pawn data selectors when the game starts
- Updated AGBFGameMode::GetPawnDataForController to take advantage of preloading
