### PR TITLE
revert_experience_additional_features

### DIFF
--- a/Source/GameBaseFramework/Private/GameFramework/Experiences/GBFExperienceDefinition.cpp
+++ b/Source/GameBaseFramework/Private/GameFramework/Experiences/GBFExperienceDefinition.cpp
@@ -18,64 +18,6 @@ FPrimaryAssetType UGBFExperienceDefinition::GetPrimaryAssetType()
     return PrimaryAssetType;
 }
 
-void UGBFExperienceDefinition::GetAllGameFeatures( TArray< FString > & features, const UWorld * world ) const
-{
-    features.Reserve( GameFeaturesToEnable.Num() * 2 );
-    features.Append( GameFeaturesToEnable );
-
-    for ( const auto * action_set : ActionSets )
-    {
-        if ( action_set != nullptr )
-        {
-            features.Append( action_set->GameFeaturesToEnable );
-        }
-    }
-
-    if ( OptionToAdditionalFeaturesAndActionsMap.IsEmpty() || !IsValid( world ) )
-    {
-        return;
-    }
-
-    const auto url = world->GetLocalURL();
-
-    for ( const auto & [ option, features_and_actions ] : OptionToAdditionalFeaturesAndActionsMap )
-    {
-        if ( url.Contains( option ) )
-        {
-            features.Append( features_and_actions.GameFeaturesToEnable );
-        }
-    }
-}
-
-void UGBFExperienceDefinition::GetAllActions( TArray< UGameFeatureAction * > & actions, const UWorld * world ) const
-{
-    actions.Reserve( Actions.Num() * 2 );
-    actions.Append( Actions );
-
-    for ( const auto * action_set : ActionSets )
-    {
-        if ( action_set != nullptr )
-        {
-            actions.Append( action_set->Actions );
-        }
-    }
-
-    if ( OptionToAdditionalFeaturesAndActionsMap.IsEmpty() || !IsValid( world ) )
-    {
-        return;
-    }
-
-    const auto url = world->GetLocalURL();
-
-    for ( const auto & [ option, features_and_actions ] : OptionToAdditionalFeaturesAndActionsMap )
-    {
-        if ( url.Contains( option ) )
-        {
-            actions.Append( features_and_actions.Actions );
-        }
-    }
-}
-
 #if WITH_EDITOR
 EDataValidationResult UGBFExperienceDefinition::IsDataValid( TArray< FText > & validation_errors )
 {

--- a/Source/GameBaseFramework/Private/GameFramework/Experiences/GBFExperienceManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/GameFramework/Experiences/GBFExperienceManagerComponent.cpp
@@ -277,10 +277,7 @@ void UGBFExperienceManagerComponent::OnExperienceLoadComplete()
     // find the URLs for our GameFeaturePlugins - filtering out dupes and ones that don't have a valid mapping
     GameFeaturePluginURLs.Reset();
 
-    TArray< FString > game_features;
-    CurrentExperience->GetAllGameFeatures( game_features, GetWorld() );
-
-    for ( const auto & plugin_name : game_features )
+    for ( const auto & plugin_name : CurrentExperience->GameFeaturesToEnable )
     {
         FString plugin_url;
         if ( UGameFeaturesSubsystem::Get().GetPluginURLForBuiltInPluginByName( plugin_name, /*out*/ plugin_url ) )
@@ -361,10 +358,7 @@ void UGBFExperienceManagerComponent::OnExperienceFullLoadCompleted()
         context.SetRequiredWorldContextHandle( existing_world_context->ContextHandle );
     }
 
-    TArray< UGameFeatureAction * > actions;
-    CurrentExperience->GetAllActions( actions, GetWorld() );
-
-    for ( auto * action : actions )
+    for ( auto * action : CurrentExperience->Actions )
     {
         if ( action != nullptr )
         {

--- a/Source/GameBaseFramework/Public/GameFramework/Experiences/GBFExperienceDefinition.h
+++ b/Source/GameBaseFramework/Public/GameFramework/Experiences/GBFExperienceDefinition.h
@@ -10,18 +10,6 @@ class UGBFPawnData;
 class UGBFExperienceActionSet;
 class UGameFeatureAction;
 
-USTRUCT()
-struct FGBFExperienceAdditionalFeaturesAndActions
-{
-    GENERATED_BODY()
-
-    UPROPERTY( EditDefaultsOnly )
-    TArray< FString > GameFeaturesToEnable;
-
-    UPROPERTY( EditDefaultsOnly, Instanced )
-    TArray< UGameFeatureAction * > Actions;
-};
-
 UCLASS( BlueprintType, Const )
 class GAMEBASEFRAMEWORK_API UGBFExperienceDefinition final : public UPrimaryDataAsset
 {
@@ -31,9 +19,6 @@ public:
     FPrimaryAssetId GetPrimaryAssetId() const override;
 
     static FPrimaryAssetType GetPrimaryAssetType();
-
-    void GetAllGameFeatures( TArray< FString > & features, const UWorld * world ) const;
-    void GetAllActions( TArray< UGameFeatureAction * > & actions, const UWorld * world ) const;
 
 #if WITH_EDITOR
     EDataValidationResult IsDataValid( TArray< FText > & validation_errors ) override;
@@ -59,7 +44,4 @@ public:
     // List of additional action sets to compose into this experience
     UPROPERTY( EditDefaultsOnly, Category = Gameplay )
     TArray< UGBFExperienceActionSet * > ActionSets;
-
-    UPROPERTY( EditDefaultsOnly, Category = Gameplay )
-    TMap< FString, FGBFExperienceAdditionalFeaturesAndActions > OptionToAdditionalFeaturesAndActionsMap;
 };


### PR DESCRIPTION
- Make getting the connection options gettable in BP
- Add functions to unregister from delegates
- Unregister hero component correctly
- Add function to global asc
- Remove ref
- Add bool to force creating new UI
- Fixed issue when a game phase starts and another phase with the same tag is active, and the cancellation policy is set to CancelNewPhase
- Don't check conditional events for abstract classes
- Add additional game features and actions
- Make sure to make the actions instanced
- Fixup checking for option
- Added delegates when asc is (un)registered in the system
- Pass url in functions so we can get url from world
- Pass in the correct urls
- refactor functions to get game features and actions
- Use action sets instead of game features + actions
- Fixup compilation
- Fixup loading and unloading features and actions
- Fix includes
- Reverse unload
- Fixup property
- return result
- filo for features
- refactor code
- const ref
- PR review
- Use game features and actions lists instead of action sets
- Fixed crash
- const auto &
- Broadcast trigger count on activate
- Add min and max for percentage
- Reverted code that allowed to specifiy additional features / actions to use base on the command line arguments
