### PR TITLE
gcc_warnings

### DIFF
--- a/Source/GameBaseFramework/Private/GAS/BlueprintAsyncActions/GBFAsyncTaskGameplayTagAddedOrRemoved.cpp
+++ b/Source/GameBaseFramework/Private/GAS/BlueprintAsyncActions/GBFAsyncTaskGameplayTagAddedOrRemoved.cpp
@@ -17,7 +17,7 @@ UGBFAsyncTaskGameplayTagAddedOrRemoved * UGBFAsyncTaskGameplayTagAddedOrRemoved:
     }
 
     wait_for_gameplay_tag_changed_task->ListenForGameplayTagChangeDelegateHandle =
-        ability_system_component->RegisterGameplayTagEvent( gameplay_tag, EGameplayTagEventType::NewOrRemoved ).AddUObject( wait_for_gameplay_tag_changed_task, &GameplayTagChanged );
+        ability_system_component->RegisterGameplayTagEvent( gameplay_tag, EGameplayTagEventType::NewOrRemoved ).AddUObject( wait_for_gameplay_tag_changed_task, &ThisClass::GameplayTagChanged );
 
     return wait_for_gameplay_tag_changed_task;
 }

--- a/Source/GameBaseFramework/Private/GAS/Components/GBFAbilitySystemComponent.cpp
+++ b/Source/GameBaseFramework/Private/GAS/Components/GBFAbilitySystemComponent.cpp
@@ -847,14 +847,14 @@ void UGBFAbilitySystemComponent::RemoveAbilityFromActivationGroup( const EGBFAbi
 
 void UGBFAbilitySystemComponent::CancelActivationGroupAbilities( const EGBFAbilityActivationGroup group, UGBFGameplayAbility * ignore_ability, bool replicate_cancel_ability )
 {
-    const auto should_cancel_func = [ this, group, ignore_ability ]( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle ability_handle ) {
-        return ( ( ability->GetActivationGroup() == group ) && ( ability != ignore_ability ) );
+    const auto should_cancel_func = [ this, group, ignore_ability ]( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle /*ability_handle*/ ) {
+        return ability->GetActivationGroup() == group && ability != ignore_ability;
     };
 
     CancelAbilitiesByFunc( should_cancel_func, replicate_cancel_ability );
 }
 
-void UGBFAbilitySystemComponent::CancelAbilitiesByFunc( TShouldCancelAbilityFunc predicate, bool replicate_cancel_ability )
+void UGBFAbilitySystemComponent::CancelAbilitiesByFunc( const TShouldCancelAbilityFunc & predicate, bool replicate_cancel_ability )
 {
     ABILITYLIST_SCOPE_LOCK();
     for ( const FGameplayAbilitySpec & ability_spec : ActivatableAbilities.Items )
@@ -902,12 +902,11 @@ void UGBFAbilitySystemComponent::CancelAbilitiesByFunc( TShouldCancelAbilityFunc
 
 void UGBFAbilitySystemComponent::CancelInputActivatedAbilities( bool replicate_cancel_ability )
 {
-    const TShouldCancelAbilityFunc predicate = [ this ]( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle handle ) {
+    CancelAbilitiesByFunc( []( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle /*handle*/ ) {
         const auto activation_policy = ability->GetActivationPolicy();
         return activation_policy == EGBFAbilityActivationPolicy::OnInputTriggered || activation_policy == EGBFAbilityActivationPolicy::WhileInputActive;
-    };
-
-    CancelAbilitiesByFunc( predicate, replicate_cancel_ability );
+    },
+        replicate_cancel_ability );
 }
 
 void UGBFAbilitySystemComponent::AbilitySpecInputPressed( FGameplayAbilitySpec & spec )

--- a/Source/GameBaseFramework/Private/GAS/Projectiles/GBFProjectile.cpp
+++ b/Source/GameBaseFramework/Private/GAS/Projectiles/GBFProjectile.cpp
@@ -104,7 +104,7 @@ bool AGBFProjectile::ShouldIgnoreHit_Implementation( AActor * other_actor, UPrim
 {
     const auto * instigator = GetInstigator();
 
-    return instigator == nullptr || bIgnoreImpactWithInstigator && other_actor == instigator;
+    return instigator == nullptr || ( bIgnoreImpactWithInstigator && other_actor == instigator );
 }
 
 void AGBFProjectile::ApplyGameplayEffects()

--- a/Source/GameBaseFramework/Private/GameFeatures/GBFGameFeatureAction_SpawnActors.cpp
+++ b/Source/GameBaseFramework/Private/GameFeatures/GBFGameFeatureAction_SpawnActors.cpp
@@ -123,7 +123,7 @@ void UGBFGameFeatureAction_SpawnActors::AddToWorld( const FWorldContext & world_
     {
         for ( const auto & actor_entry : entry.Actors )
         {
-            const bool should_spawn_actor = is_standalone || is_server && actor_entry.bSpawnOnServer || is_client && actor_entry.bSpawnOnClients;
+            const bool should_spawn_actor = is_standalone || ( is_server && actor_entry.bSpawnOnServer ) || ( is_client && actor_entry.bSpawnOnClients );
 
             if ( !should_spawn_actor )
             {

--- a/Source/GameBaseFramework/Private/GameFramework/GBFLocalMultiplayerSubsystem.cpp
+++ b/Source/GameBaseFramework/Private/GameFramework/GBFLocalMultiplayerSubsystem.cpp
@@ -92,6 +92,17 @@ TArray< ULocalPlayer * > UGBFLocalMultiplayerSubsystem::GetAllLocalPlayers() con
     return result;
 }
 
+void UGBFLocalMultiplayerSubsystem::SetForceDisableSplitscreen( bool disable )
+{
+    if ( const auto * world = GetWorld() )
+    {
+        if ( auto * viewport = Cast< UGBFGameViewportClient >( world->GetGameViewport() ) )
+        {
+            viewport->SetForceDisableSplitscreen( disable );
+        }
+    }
+}
+
 void UGBFLocalMultiplayerSubsystem::Tick( float delta_time )
 {
     Super::Tick( delta_time );

--- a/Source/GameBaseFramework/Private/Phases/GBFGamePhaseSubsystem.cpp
+++ b/Source/GameBaseFramework/Private/Phases/GBFGamePhaseSubsystem.cpp
@@ -232,7 +232,7 @@ void UGBFGamePhaseSubsystem::OnBeginPhase( const UGBFGamePhaseAbility * phase_ab
                 UE_LOG( LogGBFGamePhase, Log, TEXT( "\tEnding Phase '%s' (%s)" ), *active_phase_tag.ToString(), *GetNameSafe( active_phase_ability ) );
 
                 auto handle_to_end = active_phase->Handle;
-                game_state_asc->CancelAbilitiesByFunc( [ handle_to_end ]( const UGBFGameplayAbility * ability, const FGameplayAbilitySpecHandle handle ) {
+                game_state_asc->CancelAbilitiesByFunc( [ handle_to_end ]( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle handle ) {
                     return handle == handle_to_end;
                 },
                     true );

--- a/Source/GameBaseFramework/Private/Settings/GBFGameUserSettings.cpp
+++ b/Source/GameBaseFramework/Private/Settings/GBFGameUserSettings.cpp
@@ -1114,7 +1114,7 @@ void UGBFGameUserSettings::UpdateDesktopFramePacing()
 
 void UGBFGameUserSettings::UpdateDynamicResFrameTime( const float target_fps ) const
 {
-    if ( static auto * c_var_dy_res_frame_time_budget = IConsoleManager::Get().FindConsoleVariable( TEXT( "r.DynamicRes.FrameTimeBudget" ) ) )
+    if ( auto * c_var_dy_res_frame_time_budget = IConsoleManager::Get().FindConsoleVariable( TEXT( "r.DynamicRes.FrameTimeBudget" ) ) )
     {
         if ( ensure( target_fps > 0.0f ) )
         {

--- a/Source/GameBaseFramework/Public/GAS/Components/GBFAbilitySystemComponent.h
+++ b/Source/GameBaseFramework/Public/GAS/Components/GBFAbilitySystemComponent.h
@@ -198,7 +198,7 @@ public:
     void CancelActivationGroupAbilities( EGBFAbilityActivationGroup group, UGBFGameplayAbility * ignore_ability, bool replicate_cancel_ability );
 
     typedef TFunctionRef< bool( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle handle ) > TShouldCancelAbilityFunc;
-    void CancelAbilitiesByFunc( TShouldCancelAbilityFunc predicate, bool replicate_cancel_ability );
+    void CancelAbilitiesByFunc( const TShouldCancelAbilityFunc & predicate, bool replicate_cancel_ability );
 
     void CancelInputActivatedAbilities( bool replicate_cancel_ability );
 

--- a/Source/GameBaseFramework/Public/GameFramework/GBFLocalMultiplayerSubsystem.h
+++ b/Source/GameBaseFramework/Public/GameFramework/GBFLocalMultiplayerSubsystem.h
@@ -34,6 +34,9 @@ public:
     UFUNCTION( BlueprintPure )
     TArray< ULocalPlayer * > GetAllLocalPlayers() const;
 
+    UFUNCTION( BlueprintCallable )
+    void SetForceDisableSplitscreen( bool disable );
+
     void Tick( float delta_time ) override;
     TStatId GetStatId() const override;
 


### PR DESCRIPTION
GCC warnings:

- Missing type name for the function pointer address
- Updated signature of TShouldCancelAbilityFunc
- Added parenthesis in conditions with multiple statements
- Removed static keyword
