### PR TITLE
update EquipmentManagerComponent and EquipmentInstance

### DIFF
--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentInstance.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentInstance.cpp
@@ -86,11 +86,6 @@ void UGBFEquipmentInstance::DestroyEquipmentActors()
     }
 }
 
-void UGBFEquipmentInstance::AddSpawnedActor( AActor * spawned_actor )
-{
-    SpawnedActors.Add( spawned_actor );
-}
-
 void UGBFEquipmentInstance::OnEquipped()
 {
     K2_OnEquipped();

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentInstance.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentInstance.cpp
@@ -86,6 +86,11 @@ void UGBFEquipmentInstance::DestroyEquipmentActors()
     }
 }
 
+void UGBFEquipmentInstance::AddSpawnedActor( AActor * spawned_actor )
+{
+    SpawnedActors.Add( spawned_actor );
+}
+
 void UGBFEquipmentInstance::OnEquipped()
 {
     K2_OnEquipped();

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
@@ -191,23 +191,20 @@ UGBFEquipmentInstance * UGBFEquipmentManagerComponent::EquipItem( const TSubclas
     return result;
 }
 
-UGBFEquipmentInstance * UGBFEquipmentManagerComponent::PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition )
+void UGBFEquipmentManagerComponent::PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition )
 {
-    UGBFEquipmentInstance * result = nullptr;
     if ( equipment_instance != nullptr && equipment_definition != nullptr )
     {
-        result = EquipmentList.AddEntry( equipment_instance, equipment_definition );
-        if ( result != nullptr )
-        {
-            result->OnEquipped();
+        //:NOTE: Set the character who pick the item up as owner what is originally made at the actor spawning
+        equipment_instance->Rename( nullptr, GetOwner() );
+        EquipmentList.AddEntry( equipment_instance, equipment_definition );
+        equipment_instance->OnEquipped();
 
-            if ( IsUsingRegisteredSubObjectList() && IsReadyForReplication() )
-            {
-                AddReplicatedSubObject( result );
-            }
+        if ( IsUsingRegisteredSubObjectList() && IsReadyForReplication() )
+        {
+            AddReplicatedSubObject( equipment_instance );
         }
     }
-    return result;
 }
 
 void UGBFEquipmentManagerComponent::UnequipItem( UGBFEquipmentInstance * item_instance )

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
@@ -133,7 +133,7 @@ void FGBFEquipmentList::RemoveEntry( UGBFEquipmentInstance * instance )
                 entry.GrantedHandles.TakeFromAbilitySystem( asc );
             }
 
-            if ( !instance->ShouldBeDroppedOnGround )
+            if ( !instance->bDestroyWhenUnEquipped )
             {
                 instance->DestroyEquipmentActors();
             }
@@ -191,7 +191,7 @@ UGBFEquipmentInstance * UGBFEquipmentManagerComponent::EquipItem( const TSubclas
     return result;
 }
 
-void UGBFEquipmentManagerComponent::PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition )
+void UGBFEquipmentManagerComponent::EquipItemWithInstance( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition )
 {
     if ( equipment_instance != nullptr && equipment_definition != nullptr )
     {

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
@@ -195,7 +195,7 @@ void UGBFEquipmentManagerComponent::PickItemUp( UGBFEquipmentInstance * equipmen
 {
     if ( equipment_instance != nullptr && equipment_definition != nullptr )
     {
-        //:NOTE: Set the character who pick the item up as owner what is originally made at the actor spawning
+        //: NOTE: Set the character who pick the item up as owner what is originally made at the actor spawning
         equipment_instance->Rename( nullptr, GetOwner() );
         EquipmentList.AddEntry( equipment_instance, equipment_definition );
         equipment_instance->OnEquipped();

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
@@ -117,8 +117,8 @@ UGBFEquipmentInstance * FGBFEquipmentList::AddEntryFromExistingActor( UGBFEquipm
 
     auto & new_entry = Entries.AddDefaulted_GetRef();
     new_entry.EquipmentDefinition = equipment_definition;
-    new_entry.Instance = equipment_instance; //@TODO: Using the actor instead of component as the outer due to UE-127172
-    UGBFEquipmentInstance * result = new_entry.Instance;
+    new_entry.Instance = equipment_instance; //:TODO: Using the actor instead of component as the outer due to UE-127172
+    auto & result = new_entry.Instance;
 
     if ( auto * asc = GetAbilitySystemComponent() )
     {
@@ -129,7 +129,7 @@ UGBFEquipmentInstance * FGBFEquipmentList::AddEntryFromExistingActor( UGBFEquipm
     }
     else
     {
-        //@TODO: Warning logging?
+        //:TODO: Warning logging?
     }
 
     MarkItemDirty( new_entry );

--- a/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
+++ b/Source/GameBaseFramework/Private/Equipment/GBFEquipmentManagerComponent.cpp
@@ -91,7 +91,7 @@ UGBFEquipmentInstance * FGBFEquipmentList::AddEntryInternal( UGBFEquipmentInstan
 
     auto & new_entry = Entries.AddDefaulted_GetRef();
     new_entry.EquipmentDefinition = equipment_definition;
-    new_entry.Instance = equipment_instance; //: TODO: Using the actor instead of component as the outer due to UE-127172
+    new_entry.Instance = equipment_instance; // :TODO: Using the actor instead of component as the outer due to UE-127172
 
     if ( auto * asc = GetAbilitySystemComponent() )
     {
@@ -102,7 +102,7 @@ UGBFEquipmentInstance * FGBFEquipmentList::AddEntryInternal( UGBFEquipmentInstan
     }
     else
     {
-        //: TODO: Warning logging?
+        // :TODO: Warning logging?
     }
 
     if ( spawn_equipment_actors )
@@ -133,7 +133,7 @@ void FGBFEquipmentList::RemoveEntry( UGBFEquipmentInstance * instance )
                 entry.GrantedHandles.TakeFromAbilitySystem( asc );
             }
 
-            if ( !instance->bDestroyWhenUnEquipped )
+            if ( instance->bDestroyWhenUnEquipped )
             {
                 instance->DestroyEquipmentActors();
             }
@@ -195,7 +195,7 @@ void UGBFEquipmentManagerComponent::EquipItemWithInstance( UGBFEquipmentInstance
 {
     if ( equipment_instance != nullptr && equipment_definition != nullptr )
     {
-        //: NOTE: Set the character who pick the item up as owner what is originally made at the actor spawning
+        // :NOTE: Set the character who pick the item up as owner what is originally made at the actor spawning
         equipment_instance->Rename( nullptr, GetOwner() );
         EquipmentList.AddEntry( equipment_instance, equipment_definition );
         equipment_instance->OnEquipped();

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupDefinition.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupDefinition.cpp
@@ -1,0 +1,1 @@
+#include "Pickupable/GBFPickupDefinition.h"

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -9,6 +9,16 @@ void AGBFPickupable::PostInitializeComponents()
     CreateEquipmentInstance();
 }
 
+bool AGBFPickupable::IsDataValid()
+{
+    if ( EquipmentDefinition == nullptr )
+    {
+        return false;
+    }
+
+    return true;
+}
+
 void AGBFPickupable::CreateEquipmentInstance()
 {
     check( EquipmentDefinition != nullptr );

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -2,6 +2,7 @@
 
 #include "Equipment/GBFEquipmentDefinition.h"
 #include "Equipment/GBFEquipmentInstance.h"
+
 #include <DVEDataValidator.h>
 
 void AGBFPickupable::PostInitializeComponents()

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -2,21 +2,12 @@
 
 #include "Equipment/GBFEquipmentDefinition.h"
 #include "Equipment/GBFEquipmentInstance.h"
+#include <DVEDataValidator.h>
 
 void AGBFPickupable::PostInitializeComponents()
 {
     Super::PostInitializeComponents();
     CreateEquipmentInstance();
-}
-
-bool AGBFPickupable::IsDataValid()
-{
-    if ( EquipmentDefinition == nullptr )
-    {
-        return false;
-    }
-
-    return true;
 }
 
 void AGBFPickupable::CreateEquipmentInstance()
@@ -34,3 +25,12 @@ void AGBFPickupable::CreateEquipmentInstance()
     EquipmentInstance = NewObject< UGBFEquipmentInstance >( this, instance_type );
     EquipmentInstance->SetInstigator( this );
 }
+
+#if WITH_EDITOR
+EDataValidationResult AGBFPickupable::IsDataValid( FDataValidationContext & context ) const
+{
+    return FDVEDataValidator( context )
+        .NotNull( VALIDATOR_GET_PROPERTY( EquipmentDefinition ) )
+        .Result();
+}
+#endif

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -6,7 +6,7 @@
 void AGBFPickupable::BeginPlay()
 {
     Super::BeginPlay();
-    
+
     CreateEquipmentInstance();
 }
 

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -1,0 +1,24 @@
+#include "Pickupable/GBFPickupable.h"
+
+#include "Equipment/GBFEquipmentDefinition.h"
+#include "Equipment/GBFEquipmentInstance.h"
+
+void AGBFPickupable::BeginPlay()
+{
+    CreateEquipmentInstance();
+}
+
+void AGBFPickupable::CreateEquipmentInstance()
+{
+    check( EquipmentDefinition != nullptr );
+
+    const auto * equipment_definition_cdo = GetDefault< UGBFEquipmentDefinition >( EquipmentDefinition );
+    auto instance_type = equipment_definition_cdo->InstanceType;
+
+    if ( instance_type == nullptr )
+    {
+        instance_type = UGBFEquipmentInstance::StaticClass();
+    }
+
+    EquipmentInstance = NewObject< UGBFEquipmentInstance >( this, instance_type );
+}

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -3,10 +3,9 @@
 #include "Equipment/GBFEquipmentDefinition.h"
 #include "Equipment/GBFEquipmentInstance.h"
 
-void AGBFPickupable::BeginPlay()
+void AGBFPickupable::PostInitializeComponents()
 {
-    Super::BeginPlay();
-
+    Super::PostInitializeComponents();
     CreateEquipmentInstance();
 }
 

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -5,6 +5,8 @@
 
 void AGBFPickupable::BeginPlay()
 {
+    Super::BeginPlay();
+    
     CreateEquipmentInstance();
 }
 
@@ -21,4 +23,5 @@ void AGBFPickupable::CreateEquipmentInstance()
     }
 
     EquipmentInstance = NewObject< UGBFEquipmentInstance >( this, instance_type );
+    EquipmentInstance->SetInstigator( this );
 }

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
@@ -35,7 +35,7 @@ public:
     APawn * GetTypedPawn( TSubclassOf< APawn > pawn_type ) const;
 
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = Equipment )
-    bool ShouldBeDroppedOnGround;
+    bool bDestroyWhenUnEquipped;
 
     virtual void SpawnEquipmentActors( const TArray< FGBFEquipmentActorToSpawn > & actors_to_spawn );
     virtual void DestroyEquipmentActors();

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
@@ -34,9 +34,6 @@ public:
     UFUNCTION( BlueprintPure, Category = Equipment, meta = ( DeterminesOutputType = pawn_type ) )
     APawn * GetTypedPawn( TSubclassOf< APawn > pawn_type ) const;
 
-    UFUNCTION( BlueprintCallable, Category = Equipment )
-    void AddSpawnedActor( AActor * spawned_actor );
-
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = Equipment )
     bool ShouldBeDroppedOnGround;
 

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
@@ -34,6 +34,12 @@ public:
     UFUNCTION( BlueprintPure, Category = Equipment, meta = ( DeterminesOutputType = pawn_type ) )
     APawn * GetTypedPawn( TSubclassOf< APawn > pawn_type ) const;
 
+    UFUNCTION( BlueprintCallable, Category = Equipment )
+    void AddSpawnedActor( AActor * spawned_actor );
+
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = Equipment )
+    bool ShouldBeDroppedOnGround;
+
     virtual void SpawnEquipmentActors( const TArray< FGBFEquipmentActorToSpawn > & actors_to_spawn );
     virtual void DestroyEquipmentActors();
 

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentInstance.h
@@ -35,7 +35,7 @@ public:
     APawn * GetTypedPawn( TSubclassOf< APawn > pawn_type ) const;
 
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = Equipment )
-    bool bDestroyWhenUnEquipped;
+    uint8 bDestroyWhenUnEquipped : 1;
 
     virtual void SpawnEquipmentActors( const TArray< FGBFEquipmentActorToSpawn > & actors_to_spawn );
     virtual void DestroyEquipmentActors();

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
@@ -103,7 +103,7 @@ public:
     UGBFEquipmentInstance * EquipItem( TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
-    void PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
+    void EquipItemWithInstance( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
     void UnequipItem( UGBFEquipmentInstance * item_instance );

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
@@ -66,10 +66,11 @@ struct FGBFEquipmentList : public FFastArraySerializer
     bool NetDeltaSerialize( FNetDeltaSerializeInfo & delta_params );
     UGBFEquipmentInstance * AddEntry( TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
     void RemoveEntry( UGBFEquipmentInstance * instance );
-    UGBFEquipmentInstance * AddEntryFromExistingActor( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
+    UGBFEquipmentInstance * AddEntry( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
 private:
     UGBFAbilitySystemComponent * GetAbilitySystemComponent() const;
+    UGBFEquipmentInstance * AddEntryInternal( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition, bool spawn_equipment_actors );
 
     friend UGBFEquipmentManagerComponent;
 

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
@@ -66,6 +66,7 @@ struct FGBFEquipmentList : public FFastArraySerializer
     bool NetDeltaSerialize( FNetDeltaSerializeInfo & delta_params );
     UGBFEquipmentInstance * AddEntry( TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
     void RemoveEntry( UGBFEquipmentInstance * instance );
+    UGBFEquipmentInstance * AddEntryFromExistingActor( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
 private:
     UGBFAbilitySystemComponent * GetAbilitySystemComponent() const;
@@ -99,6 +100,9 @@ public:
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
     UGBFEquipmentInstance * EquipItem( TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
+
+    UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
+    UGBFEquipmentInstance * PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
     void UnequipItem( UGBFEquipmentInstance * item_instance );

--- a/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
+++ b/Source/GameBaseFramework/Public/Equipment/GBFEquipmentManagerComponent.h
@@ -103,7 +103,7 @@ public:
     UGBFEquipmentInstance * EquipItem( TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
-    UGBFEquipmentInstance * PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
+    void PickItemUp( UGBFEquipmentInstance * equipment_instance, TSubclassOf< UGBFEquipmentDefinition > equipment_definition );
 
     UFUNCTION( BlueprintCallable, BlueprintAuthorityOnly )
     void UnequipItem( UGBFEquipmentInstance * item_instance );

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
@@ -16,17 +16,13 @@ class GAMEBASEFRAMEWORK_API UGBFPickupDefinition : public UDataAsset
     GENERATED_BODY()
 
 public:
-    // Define the pickable equipment
-    UPROPERTY( EditAnywhere, BlueprintReadOnly )
-    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
+    // Actor to spawn instead of only display a mesh
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TSubclassOf< AActor > ActorToSpawn;
 
     // Visual of the pickup
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
     TObjectPtr< UStaticMesh > DisplayMesh;
-
-    // Actor to spawn instead of only display a mesh
-    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
-    TSubclassOf< AActor > ActorToSpawn;
 
     // Particle FX to play when picked up
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
@@ -11,14 +11,17 @@ class UGBFEquipmentDefinition;
 class UGBFGameplayAbility;
 
 UCLASS( Blueprintable, BlueprintType, Const, Meta = ( DisplayName = "GBFPickupDefinition", ShortTooltip = "Data asset used to configure a pickup." ) )
-class GAMEBASEFRAMEWORK_API UGBFPickupDefinition : public UDataAsset
+class GAMEBASEFRAMEWORK_API UGBFPickupDefinition final : public UDataAsset
 {
     GENERATED_BODY()
 
 public:
     // Actor to spawn instead of only display a mesh
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
-    TSubclassOf< AActor > ActorToSpawn;
+    TArray< TSubclassOf< AActor > > ActorToSpawn;
+
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
 
     // Visual of the pickup
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
@@ -28,10 +28,6 @@ public:
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
     TSubclassOf< AActor > ActorToSpawn;
 
-    // Cool down time between pickups in seconds
-    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
-    float SpawnCoolDownSeconds;
-
     // Particle FX to play when picked up
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
     TObjectPtr< UNiagaraSystem > PickedUpEffect;

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupDefinition.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <Engine/DataAsset.h>
+
+#include "GBFPickupDefinition.generated.h"
+
+class UNiagaraSystem;
+class UStaticMesh;
+class UGBFEquipmentDefinition;
+class UGBFGameplayAbility;
+
+UCLASS( Blueprintable, BlueprintType, Const, Meta = ( DisplayName = "GBFPickupDefinition", ShortTooltip = "Data asset used to configure a pickup." ) )
+class GAMEBASEFRAMEWORK_API UGBFPickupDefinition : public UDataAsset
+{
+    GENERATED_BODY()
+
+public:
+    // Define the pickable equipment
+    UPROPERTY( EditAnywhere, BlueprintReadOnly )
+    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
+
+    // Visual of the pickup
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TObjectPtr< UStaticMesh > DisplayMesh;
+
+    // Actor to spawn instead of only display a mesh
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TSubclassOf< AActor > ActorToSpawn;
+
+    // Cool down time between pickups in seconds
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    float SpawnCoolDownSeconds;
+
+    // Particle FX to play when picked up
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TObjectPtr< UNiagaraSystem > PickedUpEffect;
+
+    // Particle FX to play when pickup is respawned
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TObjectPtr< UNiagaraSystem > RespawnedEffect;
+};

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -20,6 +20,8 @@ public:
 
 private:
     void CreateEquipmentInstance();
+    UFUNCTION( BlueprintPure )
+    bool IsDataValid();
 
     // Defines the equipment definition of the pickupable
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -21,7 +21,7 @@ public:
 private:
     void CreateEquipmentInstance();
 
-    // define the equipment definition of the pickupable
+    // Defines the equipment definition of the pickupable
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
 

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -18,14 +18,15 @@ class GAMEBASEFRAMEWORK_API AGBFPickupable : public AGBFInteractableActor
 public:
     void BeginPlay() override;
 
-    // define the equipment definition of the pickupable
-    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
-    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
 
 private:
     void CreateEquipmentInstance();
 
+    // define the equipment definition of the pickupable
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
+    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
+
     // The Equipment Instance from the equipmentdefition to fit with the EquipmentManager
-    UPROPERTY( EditAnywhere, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
+    UPROPERTY( BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     TObjectPtr< UGBFEquipmentInstance > EquipmentInstance;
 };

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -16,7 +16,7 @@ class GAMEBASEFRAMEWORK_API AGBFPickupable : public AGBFInteractableActor
     GENERATED_BODY()
 
 public:
-    void BeginPlay() override;
+    void PostInitializeComponents() override;
 
 private:
     void CreateEquipmentInstance();
@@ -26,6 +26,6 @@ private:
     TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
 
     // The Equipment Instance from the equipmentdefition to fit with the EquipmentManager
-    UPROPERTY( BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
+    UPROPERTY( BlueprintReadOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     TObjectPtr< UGBFEquipmentInstance > EquipmentInstance;
 };

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -17,11 +17,12 @@ class GAMEBASEFRAMEWORK_API AGBFPickupable : public AGBFInteractableActor
 
 public:
     void PostInitializeComponents() override;
+#if WITH_EDITOR
+    EDataValidationResult IsDataValid( FDataValidationContext & context ) const override;
+#endif
 
 private:
     void CreateEquipmentInstance();
-    UFUNCTION( BlueprintPure )
-    bool IsDataValid();
 
     // Defines the equipment definition of the pickupable
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -26,6 +26,6 @@ private:
     TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
 
     // The Equipment Instance from the equipmentdefition to fit with the EquipmentManager
-    UPROPERTY( BlueprintReadOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
+    UPROPERTY( VisibleInstanceOnly, BlueprintReadOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
     TObjectPtr< UGBFEquipmentInstance > EquipmentInstance;
 };

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -18,7 +18,6 @@ class GAMEBASEFRAMEWORK_API AGBFPickupable : public AGBFInteractableActor
 public:
     void BeginPlay() override;
 
-
 private:
     void CreateEquipmentInstance();
 

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Interaction/GBFInteractableActor.h"
+
+#include <CoreMinimal.h>
+
+#include "GBFPickupable.generated.h"
+
+class AGBFInteractableActor;
+class UGBFEquipmentInstance;
+class UGBFEquipmentDefinition;
+
+UCLASS( Abstract, Blueprintable, Meta = ( DisplayName = "GBFPickupable" ) )
+class GAMEBASEFRAMEWORK_API AGBFPickupable : public AGBFInteractableActor
+{
+    GENERATED_BODY()
+
+public:
+    void BeginPlay() override;
+
+    // define the equipment definition of the pickupable
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly )
+    TSubclassOf< UGBFEquipmentDefinition > EquipmentDefinition;
+
+private:
+    void CreateEquipmentInstance();
+
+    // The Equipment Instance from the equipmentdefition to fit with the EquipmentManager
+    UPROPERTY( EditAnywhere, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )
+    TObjectPtr< UGBFEquipmentInstance > EquipmentInstance;
+};


### PR DESCRIPTION
Update EquipmentInstance to be able to don't destroy the associated actor(s) instantly on UnEquip.
Update EquipmentManagerComponent to avoid instancing new actors everytime we want to EquipItem : 
* Add PickItemUp() Method to avoid using EquipItem ( which instanciate new actors )
* Add AddEntryFromExistingActor() to avoid creating new EquipmentInstance and loose reference with the already existing one

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TheEmidee/UEGameBaseFramework/228)
<!-- Reviewable:end -->
