### PR TITLE
add show confirmation dialogs with custom widget

### DIFF
--- a/Source/GameBaseFramework/Private/UI/SubSystems/GBFUIMessagingSubsystem.cpp
+++ b/Source/GameBaseFramework/Private/UI/SubSystems/GBFUIMessagingSubsystem.cpp
@@ -15,13 +15,13 @@ void UGBFUIMessagingSubsystem::Initialize( FSubsystemCollectionBase & collection
     ErrorDialogClassPtr = settings->ErrorDialogClass.LoadSynchronous();
 }
 
-void UGBFUIMessagingSubsystem::ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, FCommonMessagingResultDelegate result_callback )
+void UGBFUIMessagingSubsystem::ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget, FCommonMessagingResultDelegate result_callback )
 {
     if ( const auto * local_player = GetLocalPlayer< UGBFLocalPlayer >() )
     {
         if ( auto * root_layout = local_player->GetRootUILayout() )
         {
-            root_layout->PushWidgetToLayerStack< UCommonGameDialog >( GBFTag_UI_Layer_Modal, ConfirmationDialogClassPtr, [ dialog_descriptor, result_callback ]( UCommonGameDialog & dialog ) {
+            root_layout->PushWidgetToLayerStack< UCommonGameDialog >( GBFTag_UI_Layer_Modal, custom_dialog_widget != nullptr ? custom_dialog_widget : ConfirmationDialogClassPtr, [ dialog_descriptor, result_callback ]( UCommonGameDialog & dialog ) {
                 dialog.SetupDialog( dialog_descriptor, result_callback );
             } );
         }

--- a/Source/GameBaseFramework/Public/UI/SubSystems/GBFUIMessagingSubsystem.h
+++ b/Source/GameBaseFramework/Public/UI/SubSystems/GBFUIMessagingSubsystem.h
@@ -13,8 +13,7 @@ class GAMEBASEFRAMEWORK_API UGBFUIMessagingSubsystem final : public UCommonMessa
 
 public:
     void Initialize( FSubsystemCollectionBase & collection ) override;
-
-    void ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, FCommonMessagingResultDelegate result_callback = FCommonMessagingResultDelegate() ) override;
+    void ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget = nullptr, FCommonMessagingResultDelegate result_callback = FCommonMessagingResultDelegate() ) override;
     void ShowError( UCommonGameDialogDescriptor * dialog_descriptor, FCommonMessagingResultDelegate result_callback = FCommonMessagingResultDelegate() ) override;
 
 private:


### PR DESCRIPTION
please check  https://github.com/TheEmidee/UECommonGame/pull/1 for the entire feature

Add the possibility to use specific widget instead of the common one for confirmation dialogs.

I've chosen to modify the existing methods instead of creating overloads because at the end. It was resulting that in `UAsyncAction_ShowConfirmation::Activate()` I had to check if `CustomDialogWidge`t is nullptr or not to call the old or the new `ShowConfirmation()` method ( for the olds node still working).
And since calling the old method, called the new one with the Common widget as parameter, I m thinking that this way the code is more readable and understandable avoiding overloads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TheEmidee/UEGameBaseFramework/243)
<!-- Reviewable:end -->
