### PR TITLE
ability task wait so interaction

### DIFF
--- a/GameBaseFramework.uplugin
+++ b/GameBaseFramework.uplugin
@@ -102,6 +102,26 @@
     {
       "Name": "UIExtension",
       "Enabled": true
+    },
+    {
+      "Name": "SmartObjects",
+      "Enabled": true
+    },
+    {
+      "Name": "GameplayBehaviors",
+      "Enabled": true
+    },
+    {
+      "Name": "GameplayBehaviorSmartObjects",
+      "Enabled": true
+    },
+    {
+      "Name": "GameplayInteractions",
+      "Enabled": true
+    },
+    {
+      "Name": "StateTree",
+      "Enabled": true
     }
   ]
 }

--- a/Source/GameBaseFramework/GameBaseFramework.Build.cs
+++ b/Source/GameBaseFramework/GameBaseFramework.Build.cs
@@ -59,7 +59,8 @@ namespace UnrealBuildTool.Rules
                     "GameplayBehaviorsModule",
                     "GameplayBehaviorSmartObjectsModule",
                     "GameplayInteractionsModule",
-                    "StateTreeModule"
+                    "StateTreeModule",
+                    "StructUtils"
                 }
             );
         }

--- a/Source/GameBaseFramework/GameBaseFramework.Build.cs
+++ b/Source/GameBaseFramework/GameBaseFramework.Build.cs
@@ -54,7 +54,12 @@ namespace UnrealBuildTool.Rules
                     "EngineSettings",
                     "Niagara",
                     "PhysicsCore",
-                    "GameplayMessageRuntime"
+                    "GameplayMessageRuntime",
+                    "SmartObjectsModule",
+                    "GameplayBehaviorsModule",
+                    "GameplayBehaviorSmartObjectsModule",
+                    "GameplayInteractionsModule",
+                    "StateTreeModule"
                 }
             );
         }

--- a/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
+++ b/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
@@ -1,0 +1,184 @@
+#include "GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h"
+
+#include <GameplayBehavior.h>
+#include <GameplayInteractionSmartObjectBehaviorDefinition.h>
+#include <Misc/ScopeExit.h>
+#include <SmartObjectComponent.h>
+#include <SmartObjectSubsystem.h>
+#include <VisualLogger/VisualLogger.h>
+
+UGBFAT_WaitUseSmartObjectGameplayBehavior::UGBFAT_WaitUseSmartObjectGameplayBehavior( const FObjectInitializer & object_initializer ) :
+    Super( object_initializer )
+{
+    bTickingTask = true;
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::Activate()
+{
+    Super::Activate();
+
+    SetWaitingOnAvatar();
+
+    bool bSuccess = false;
+    ON_SCOPE_EXIT
+    {
+        if ( !bSuccess )
+        {
+            EndTask();
+        }
+    };
+
+    if ( !ClaimedHandle.IsValid() )
+    {
+        return;
+    }
+
+    auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( GetAvatarActor()->GetWorld() );
+    if ( !ensureMsgf( smart_object_subsystem != nullptr, TEXT( "SmartObjectSubsystem must be accessible at this point." ) ) )
+    {
+        return;
+    }
+
+    // A valid claimed handle can point to an object that is no longer part of the simulation
+    if ( !smart_object_subsystem->IsClaimedSmartObjectValid( ClaimedHandle ) )
+    {
+        UE_VLOG( GetAvatarActor(), LogSmartObject, Log, TEXT( "Claim handle: %s refers to an object that is no longer available." ), *LexToString( ClaimedHandle ) );
+        return;
+    }
+
+    // Register a callback to be notified if the claimed slot became unavailable
+    smart_object_subsystem->RegisterSlotInvalidationCallback( ClaimedHandle, FOnSlotInvalidated::CreateUObject( this, &ThisClass::OnSlotInvalidated ) );
+
+    bSuccess = StartInteraction();
+}
+
+UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component )
+{
+    auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( owning_ability->GetWorld() );
+
+    const auto registered_handle = smart_object_component->GetRegisteredHandle();
+
+    TArray< FSmartObjectSlotHandle > slots;
+    smart_object_subsystem->GetAllSlots( registered_handle, slots );
+
+    FSmartObjectClaimHandle claim_handle;
+
+    for ( const auto slot_handle : slots )
+    {
+        if ( smart_object_subsystem->CanBeClaimed( slot_handle ) )
+        {
+            claim_handle = smart_object_subsystem->MarkSlotAsClaimed( slot_handle );
+            break;
+        }
+    }
+
+    return WaitUseSmartObjectGameplayBehaviorWithClaimHandle( owning_ability, claim_handle );
+}
+
+UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSlotHandle( UGameplayAbility * owning_ability, FSmartObjectSlotHandle slot_handle )
+{
+    auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( owning_ability->GetWorld() );
+    const auto claim_handle = smart_object_subsystem->MarkSlotAsClaimed( slot_handle );
+
+    return WaitUseSmartObjectGameplayBehaviorWithClaimHandle( owning_ability, claim_handle );
+}
+
+UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithClaimHandle( UGameplayAbility * owning_ability, FSmartObjectClaimHandle claim_handle )
+{
+    auto * task = NewAbilityTask< UGBFAT_WaitUseSmartObjectGameplayBehavior >( owning_ability );
+    task->ClaimedHandle = claim_handle;
+    return task;
+}
+
+bool UGBFAT_WaitUseSmartObjectGameplayBehavior::StartInteraction()
+{
+    const auto * world = GetAvatarActor()->GetWorld();
+    auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( world );
+    if ( !ensure( smart_object_subsystem ) )
+    {
+        return false;
+    }
+
+    const auto * behavior_definition = smart_object_subsystem->MarkSlotAsOccupied< UGameplayInteractionSmartObjectBehaviorDefinition >( ClaimedHandle );
+    if ( behavior_definition == nullptr )
+    {
+        UE_VLOG_UELOG( GetAvatarActor(), LogGameplayInteractions, Error, TEXT( "SmartObject was claimed for a different type of behavior definition. Expecting: %s." ), *UGameplayInteractionSmartObjectBehaviorDefinition::StaticClass()->GetName() );
+        return false;
+    }
+
+    const auto * smart_object_component = smart_object_subsystem->GetSmartObjectComponent( ClaimedHandle );
+    GameplayInteractionContext.SetContextActor( GetAvatarActor() );
+    GameplayInteractionContext.SetSmartObjectActor( smart_object_component ? smart_object_component->GetOwner() : nullptr );
+    GameplayInteractionContext.SetClaimedHandle( ClaimedHandle );
+
+    return GameplayInteractionContext.Activate( *behavior_definition );
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::Abort( const EGameplayInteractionAbortReason reason )
+{
+    AbortContext.Reason = reason;
+
+    if ( !bInteractionCompleted )
+    {
+        GameplayInteractionContext.SetAbortContext( AbortContext );
+    }
+
+    EndTask();
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::OnDestroy( bool ability_ended )
+{
+    if ( ClaimedHandle.IsValid() )
+    {
+        auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( GetAvatarActor()->GetWorld() );
+        check( smart_object_subsystem != nullptr );
+
+        smart_object_subsystem->MarkSlotAsFree( ClaimedHandle );
+        smart_object_subsystem->UnregisterSlotInvalidationCallback( ClaimedHandle );
+
+        ClaimedHandle.Invalidate();
+    }
+
+    if ( TaskState != EGameplayTaskState::Finished )
+    {
+        if ( AbortContext.Reason == EGameplayInteractionAbortReason::Unset && bInteractionCompleted )
+        {
+            OnSucceeded.Broadcast();
+        }
+        else
+        {
+            OnFailed.Broadcast();
+        }
+    }
+
+    Super::OnDestroy( ability_ended );
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::TickTask( float delta_time )
+{
+    Super::TickTask( delta_time );
+
+    const auto keep_ticking = GameplayInteractionContext.Tick( delta_time );
+    if ( !keep_ticking )
+    {
+        bInteractionCompleted = true;
+        EndTask();
+    }
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::OnSlotInvalidated( const FSmartObjectClaimHandle & /*claim_handle*/, ESmartObjectSlotState /*state*/ )
+{
+    Abort( EGameplayInteractionAbortReason::InternalAbort );
+}
+
+void UGBFAT_WaitUseSmartObjectGameplayBehavior::OnSmartObjectBehaviorFinished( UGameplayBehavior & behavior, AActor & avatar, const bool interrupted )
+{
+    // make sure we handle the right pawn - we can get this notify for a different
+    // Avatar if the behavior sending it out is not instanced (CDO is being used to perform actions)
+    if ( GetAvatarActor() == &avatar )
+    {
+        behavior.GetOnBehaviorFinishedDelegate().Remove( OnBehaviorFinishedNotifyHandle );
+        bInteractionCompleted = true;
+        EndTask();
+    }
+}

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -39,8 +39,13 @@ UGBFEquipmentInstance * AGBFPickupable::CreateEquipmentInstance()
 #if WITH_EDITOR
 EDataValidationResult AGBFPickupable::IsDataValid( FDataValidationContext & context ) const
 {
-    return FDVEDataValidator( context )
-        .NotNull( VALIDATOR_GET_PROPERTY( EquipmentDefinition ) )
-        .Result();
+    if ( !GetClass()->HasAnyClassFlags( CLASS_Abstract ) )
+    {
+        return FDVEDataValidator( context )
+            .NotNull( VALIDATOR_GET_PROPERTY( EquipmentDefinition ) )
+            .Result();
+    }
+
+    return EDataValidationResult::Valid;
 }
 #endif

--- a/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
+++ b/Source/GameBaseFramework/Private/Pickupable/GBFPickupable.cpp
@@ -8,24 +8,32 @@
 void AGBFPickupable::PostInitializeComponents()
 {
     Super::PostInitializeComponents();
-    CreateEquipmentInstance();
-    EquipmentInstance->Initialize();
+
+    if ( auto * equipment_instance = CreateEquipmentInstance() )
+    {
+        equipment_instance->Initialize();
+    }
 }
 
-void AGBFPickupable::CreateEquipmentInstance()
+UGBFEquipmentInstance * AGBFPickupable::CreateEquipmentInstance()
 {
-    check( EquipmentDefinition != nullptr );
-
-    const auto * equipment_definition_cdo = GetDefault< UGBFEquipmentDefinition >( EquipmentDefinition );
-    auto instance_type = equipment_definition_cdo->InstanceType;
-
-    if ( instance_type == nullptr )
+    if ( EquipmentDefinition != nullptr )
     {
-        instance_type = UGBFEquipmentInstance::StaticClass();
+        const auto * equipment_definition_cdo = GetDefault< UGBFEquipmentDefinition >( EquipmentDefinition );
+        auto instance_type = equipment_definition_cdo->InstanceType;
+
+        if ( instance_type == nullptr )
+        {
+            instance_type = UGBFEquipmentInstance::StaticClass();
+        }
+
+        EquipmentInstance = NewObject< UGBFEquipmentInstance >( this, instance_type );
+        EquipmentInstance->SetInstigator( this );
+
+        return EquipmentInstance;
     }
 
-    EquipmentInstance = NewObject< UGBFEquipmentInstance >( this, instance_type );
-    EquipmentInstance->SetInstigator( this );
+    return nullptr;
 }
 
 #if WITH_EDITOR

--- a/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
+++ b/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
@@ -10,6 +10,15 @@
 
 class UGameplayBehavior;
 class USmartObjectComponent;
+
+UENUM( BlueprintType )
+enum class EGBFATSmartObjectComponentSlotSelection : uint8
+{
+    First,
+    Closest,
+    Random
+};
+
 UCLASS()
 class GAMEBASEFRAMEWORK_API UGBFAT_WaitUseSmartObjectGameplayBehavior final : public UAbilityTask
 {
@@ -22,7 +31,7 @@ public:
     void Activate() override;
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
-    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component );
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection );
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
     static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSlotHandle( UGameplayAbility * owning_ability, FSmartObjectSlotHandle slot_handle );

--- a/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
+++ b/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
@@ -5,6 +5,7 @@
 #include <GameplayInteractionContext.h>
 #include <SmartObjectRuntime.h>
 #include <SmartObjectTypes.h>
+#include <StructView.h>
 
 #include "GBFAT_WaitUseSmartObjectGameplayBehavior.generated.h"
 
@@ -19,13 +20,27 @@ enum class EGBFATSmartObjectComponentSlotSelection : uint8
     Random
 };
 
+UCLASS( BlueprintType )
+class UGBFWaitUseSmartObjectProxy : public UObject
+{
+    GENERATED_BODY()
+
+public:
+    UFUNCTION( BlueprintCallable )
+    void SendEventToStateTree( const FGameplayTag tag );
+
+    UPROPERTY()
+    FGameplayInteractionContext GameplayInteractionContext;
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam( FOnWaitUseSmartObjectGameplayBehaviorActivated, UGBFWaitUseSmartObjectProxy *, Proxy );
+
 UCLASS()
 class GAMEBASEFRAMEWORK_API UGBFAT_WaitUseSmartObjectGameplayBehavior final : public UAbilityTask
 {
     GENERATED_BODY()
 
 public:
-
     explicit UGBFAT_WaitUseSmartObjectGameplayBehavior( const FObjectInitializer & object_initializer );
 
     void Activate() override;
@@ -49,13 +64,16 @@ private:
     void OnSmartObjectBehaviorFinished( UGameplayBehavior & behavior, AActor & avatar, const bool interrupted );
 
     UPROPERTY( BlueprintAssignable )
+    FOnWaitUseSmartObjectGameplayBehaviorActivated OnActivated;
+
+    UPROPERTY( BlueprintAssignable )
     FGenericGameplayTaskDelegate OnSucceeded;
 
     UPROPERTY( BlueprintAssignable )
     FGenericGameplayTaskDelegate OnFailed;
 
     UPROPERTY()
-    FGameplayInteractionContext GameplayInteractionContext;
+    TObjectPtr< UGBFWaitUseSmartObjectProxy > SmartObjectProxy;
 
     UPROPERTY()
     FGameplayInteractionAbortContext AbortContext;

--- a/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
+++ b/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Abilities/Tasks/AbilityTask.h>
+#include <CoreMinimal.h>
+#include <GameplayInteractionContext.h>
+#include <SmartObjectRuntime.h>
+#include <SmartObjectTypes.h>
+
+#include "GBFAT_WaitUseSmartObjectGameplayBehavior.generated.h"
+
+class UGameplayBehavior;
+class USmartObjectComponent;
+UCLASS()
+class GAMEBASEFRAMEWORK_API UGBFAT_WaitUseSmartObjectGameplayBehavior final : public UAbilityTask
+{
+    GENERATED_BODY()
+
+public:
+
+    explicit UGBFAT_WaitUseSmartObjectGameplayBehavior( const FObjectInitializer & object_initializer );
+
+    void Activate() override;
+
+    UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component );
+
+    UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSlotHandle( UGameplayAbility * owning_ability, FSmartObjectSlotHandle slot_handle );
+
+    UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithClaimHandle( UGameplayAbility * owning_ability, FSmartObjectClaimHandle claim_handle );
+
+private:
+    bool StartInteraction();
+    void Abort( const EGameplayInteractionAbortReason reason );
+    void OnDestroy( bool ability_ended ) override;
+    void TickTask( float delta_time ) override;
+
+    void OnSlotInvalidated( const FSmartObjectClaimHandle & claim_handle, ESmartObjectSlotState state );
+    void OnSmartObjectBehaviorFinished( UGameplayBehavior & behavior, AActor & avatar, const bool interrupted );
+
+    UPROPERTY( BlueprintAssignable )
+    FGenericGameplayTaskDelegate OnSucceeded;
+
+    UPROPERTY( BlueprintAssignable )
+    FGenericGameplayTaskDelegate OnFailed;
+
+    UPROPERTY()
+    FGameplayInteractionContext GameplayInteractionContext;
+
+    UPROPERTY()
+    FGameplayInteractionAbortContext AbortContext;
+
+    FSmartObjectClaimHandle ClaimedHandle;
+    FDelegateHandle OnBehaviorFinishedNotifyHandle;
+    bool bInteractionCompleted;
+};

--- a/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
+++ b/Source/GameBaseFramework/Public/Pickupable/GBFPickupable.h
@@ -22,7 +22,7 @@ public:
 #endif
 
 private:
-    void CreateEquipmentInstance();
+    UGBFEquipmentInstance * CreateEquipmentInstance();
 
     // Defines the equipment definition of the pickupable
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, meta = ( AllowPrivateAccess = true ) )


### PR DESCRIPTION
- Check for nullness of asc when registering interactions
- Created ability task to play a contextual animation on a SO
- Added option to select which slot of a SO component to use
- Added OnActivated delegate that returns a proxy class that allows to send event to the state tree asset managing the interaction
- Check pointers when equipping an item instance
- Don't run IsDataValid on abstract equipment instances
