### PR TITLE
Update interaction widget display

### DIFF
--- a/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
+++ b/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
@@ -2,6 +2,7 @@
 
 #include "BlueprintLibraries/CoreExtArrayBlueprintLibrary.h"
 
+#include <AbilitySystemComponent.h>
 #include <GameplayBehavior.h>
 #include <GameplayInteractionSmartObjectBehaviorDefinition.h>
 #include <Misc/ScopeExit.h>
@@ -66,15 +67,19 @@ void UGBFAT_WaitUseSmartObjectGameplayBehavior::Activate()
     }
 }
 
-UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, FSmartObjectRequestFilter user_tags_filter )
+UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, const TArray< TSubclassOf< USmartObjectBehaviorDefinition > > behavior_definition_classes, const FGameplayTagQuery activity_tags )
 {
     auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( owning_ability->GetWorld() );
 
     const auto registered_handle = smart_object_component->GetRegisteredHandle();
 
-    TArray< FSmartObjectSlotHandle > slots;
+    FSmartObjectRequestFilter smart_object_request_filter;
+    owning_ability->GetAbilitySystemComponentFromActorInfo()->GetOwnedGameplayTags( smart_object_request_filter.UserTags );
+    smart_object_request_filter.BehaviorDefinitionClasses = behavior_definition_classes;
+    smart_object_request_filter.ActivityRequirements = activity_tags;
 
-    smart_object_subsystem->FindSlots( registered_handle, user_tags_filter, slots );
+    TArray< FSmartObjectSlotHandle > slots;
+    smart_object_subsystem->FindSlots( registered_handle, smart_object_request_filter, slots );
 
     FSmartObjectClaimHandle claim_handle( FSmartObjectClaimHandle::InvalidHandle );
 

--- a/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
+++ b/Source/GameBaseFramework/Private/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.cpp
@@ -66,14 +66,15 @@ void UGBFAT_WaitUseSmartObjectGameplayBehavior::Activate()
     }
 }
 
-UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection )
+UGBFAT_WaitUseSmartObjectGameplayBehavior * UGBFAT_WaitUseSmartObjectGameplayBehavior::WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, FSmartObjectRequestFilter user_tags_filter )
 {
     auto * smart_object_subsystem = USmartObjectSubsystem::GetCurrent( owning_ability->GetWorld() );
 
     const auto registered_handle = smart_object_component->GetRegisteredHandle();
 
     TArray< FSmartObjectSlotHandle > slots;
-    smart_object_subsystem->GetAllSlots( registered_handle, slots );
+
+    smart_object_subsystem->FindSlots( registered_handle, user_tags_filter, slots );
 
     FSmartObjectClaimHandle claim_handle( FSmartObjectClaimHandle::InvalidHandle );
 

--- a/Source/GameBaseFramework/Private/Interaction/Abilities/GBFGameplayAbility_Interact.cpp
+++ b/Source/GameBaseFramework/Private/Interaction/Abilities/GBFGameplayAbility_Interact.cpp
@@ -286,7 +286,7 @@ void UGBFGameplayAbility_Interact::RegisterInteraction( const InteractableTarget
         }
 
         has_a_matching_sub_option = true;
-        
+
         break;
     }
 

--- a/Source/GameBaseFramework/Private/Interaction/Abilities/GBFGameplayAbility_Interact.cpp
+++ b/Source/GameBaseFramework/Private/Interaction/Abilities/GBFGameplayAbility_Interact.cpp
@@ -271,6 +271,30 @@ void UGBFGameplayAbility_Interact::RegisterInteraction( const InteractableTarget
         return;
     }
 
+    bool has_a_matching_sub_option = false;
+
+    for ( auto sub_option : option_container.Options )
+    {
+        if ( !sub_option.InstigatorTagRequirements.RequirementsMet( actor_info_tags ) )
+        {
+            continue;
+        }
+
+        if ( !sub_option.InteractableTargetTagRequirements.RequirementsMet( interactable_target_tags ) )
+        {
+            continue;
+        }
+
+        has_a_matching_sub_option = true;
+        
+        break;
+    }
+
+    if ( !has_a_matching_sub_option )
+    {
+        return;
+    }
+
     context.WidgetInfosHandles.Emplace( interactable_target, option_container.CommonWidgetInfos );
 
     if ( const auto * pc = Cast< APlayerController >( pawn->GetController() ) )

--- a/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
+++ b/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
@@ -5,7 +5,6 @@
 #include <GameplayInteractionContext.h>
 #include <SmartObjectRuntime.h>
 #include <SmartObjectTypes.h>
-#include <StructView.h>
 
 #include "GBFAT_WaitUseSmartObjectGameplayBehavior.generated.h"
 
@@ -46,7 +45,7 @@ public:
     void Activate() override;
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
-    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, FSmartObjectRequestFilter user_tags_filter );
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, const TArray< TSubclassOf< USmartObjectBehaviorDefinition > > behavior_definition_classes, const FGameplayTagQuery activity_tags );
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
     static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSlotHandle( UGameplayAbility * owning_ability, FSmartObjectSlotHandle slot_handle );

--- a/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
+++ b/Source/GameBaseFramework/Public/GAS/Tasks/GBFAT_WaitUseSmartObjectGameplayBehavior.h
@@ -46,7 +46,7 @@ public:
     void Activate() override;
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
-    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection );
+    static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent( UGameplayAbility * owning_ability, USmartObjectComponent * smart_object_component, EGBFATSmartObjectComponentSlotSelection slot_selection, FSmartObjectRequestFilter user_tags_filter );
 
     UFUNCTION( BlueprintCallable, Category = "Ability|Tasks", meta = ( HidePin = "owning_ability", DefaultToSelf = "owning_ability", BlueprintInternalUseOnly = "TRUE" ) )
     static UGBFAT_WaitUseSmartObjectGameplayBehavior * WaitUseSmartObjectGameplayBehaviorWithSlotHandle( UGameplayAbility * owning_ability, FSmartObjectSlotHandle slot_handle );


### PR DESCRIPTION
Use user tags to filter slots selection of smartobject component when using `WaitUseSmartObjectGameplayBehaviorWithSmartObjectComponent`

check suboptions of interactable actor to check if at least one interaction is triggerable before displaying the widget

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TheEmidee/UEGameBaseFramework/268)
<!-- Reviewable:end -->
