### PR TITLE
PawnData improvements

### DIFF
--- a/Source/GameBaseFramework/Private/Characters/Components/GBFHeroComponent.cpp
+++ b/Source/GameBaseFramework/Private/Characters/Components/GBFHeroComponent.cpp
@@ -286,44 +286,47 @@ void UGBFHeroComponent::InitializePlayerInput( UInputComponent * player_input_co
     {
         if ( const auto * pawn_data = pawn_ext_comp->GetPawnData< UGBFPawnData >() )
         {
-            if ( const auto * input_config = pawn_data->InputConfig.Get() )
+            for ( const auto & input_config_ptr : pawn_data->InputConfigs )
             {
-                FModifyContextOptions options = {};
-                options.bIgnoreAllPressedKeysUntilRelease = false;
-
-                for ( const auto & mapping : DefaultInputMappings )
+                if ( const auto * input_config = input_config_ptr.Get() )
                 {
-                    if ( const auto * imc = mapping.InputMapping.LoadSynchronous() )
+                    FModifyContextOptions options = {};
+                    options.bIgnoreAllPressedKeysUntilRelease = false;
+
+                    for ( const auto & mapping : DefaultInputMappings )
                     {
-                        if ( mapping.bRegisterWithSettings )
+                        if ( const auto * imc = mapping.InputMapping.LoadSynchronous() )
                         {
-                            if ( auto * settings = enhanced_input_local_player_subsystem->GetUserSettings() )
+                            if ( mapping.bRegisterWithSettings )
                             {
-                                settings->RegisterInputMappingContext( imc );
-                            }
+                                if ( auto * settings = enhanced_input_local_player_subsystem->GetUserSettings() )
+                                {
+                                    settings->RegisterInputMappingContext( imc );
+                                }
 
-                            enhanced_input_local_player_subsystem->AddMappingContext( imc, mapping.Priority, options );
-                        }
-                        else
-                        {
-                            if ( auto * settings = enhanced_input_local_player_subsystem->GetUserSettings() )
+                                enhanced_input_local_player_subsystem->AddMappingContext( imc, mapping.Priority, options );
+                            }
+                            else
                             {
-                                settings->UnregisterInputMappingContext( imc );
-                            }
+                                if ( auto * settings = enhanced_input_local_player_subsystem->GetUserSettings() )
+                                {
+                                    settings->UnregisterInputMappingContext( imc );
+                                }
 
-                            enhanced_input_local_player_subsystem->RemoveMappingContext( imc, options );
+                                enhanced_input_local_player_subsystem->RemoveMappingContext( imc, options );
+                            }
                         }
                     }
-                }
 
-                auto * input_component = CastChecked< UGBFInputComponent >( player_input_component );
+                    auto * input_component = CastChecked< UGBFInputComponent >( player_input_component );
 
-                if ( ensureMsgf( input_component != nullptr, TEXT( "Unexpected Input Component class! The Gameplay Abilities will not be bound to their inputs. Change the input component to UGBFInputComponent or a subclass of it." ) ) )
-                {
-                    input_component->AddInputMappings( input_config, enhanced_input_local_player_subsystem );
+                    if ( ensureMsgf( input_component != nullptr, TEXT( "Unexpected Input Component class! The Gameplay Abilities will not be bound to their inputs. Change the input component to UGBFInputComponent or a subclass of it." ) ) )
+                    {
+                        input_component->AddInputMappings( input_config, enhanced_input_local_player_subsystem );
 
-                    AddAdditionalInputConfig( input_config );
-                    BindNativeActions( input_component, input_config );
+                        AddAdditionalInputConfig( input_config );
+                        BindNativeActions( input_component, input_config );
+                    }
                 }
             }
         }

--- a/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
+++ b/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
@@ -5,6 +5,7 @@
 #include <UObject/Package.h>
 
 const FGuid FGBFPawnDataObjectVersion::GUID( 0xDF2EDE03, 0xB6C04878, 0x84770B08, 0x1B0C34BE );
+FCustomVersionRegistration GRegisterPawnDataObjectVersion( FGBFPawnDataObjectVersion::GUID, FGBFPawnDataObjectVersion::LatestVersion, TEXT( "GBFPawnData" ) );
 
 UGBFPawnData::UGBFPawnData()
 {

--- a/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
+++ b/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
@@ -4,6 +4,8 @@
 
 #include <UObject/Package.h>
 
+const FGuid FGBFPawnDataObjectVersion::GUID( 0xDF2EDE03, 0xB6C04878, 0x84770B08, 0x1B0C34BE );
+
 UGBFPawnData::UGBFPawnData()
 {
     PawnClass = nullptr;
@@ -13,6 +15,19 @@ UGBFPawnData::UGBFPawnData()
 FPrimaryAssetId UGBFPawnData::GetPrimaryAssetId() const
 {
     return FPrimaryAssetId( TEXT( "PawnData" ), GetPackage()->GetFName() );
+}
+
+void UGBFPawnData::Serialize( FArchive & archive )
+{
+    Super::Serialize( archive );
+
+    archive.UsingCustomVersion( FGBFPawnDataObjectVersion::GUID );
+
+    if ( archive.CustomVer( FGBFPawnDataObjectVersion::GUID ) < FGBFPawnDataObjectVersion::MultipleInputConfigs )
+    {
+        InputConfigs.AddUnique( InputConfig );
+        InputConfig = nullptr;
+    }
 }
 
 #if WITH_EDITOR

--- a/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
+++ b/Source/GameBaseFramework/Private/Characters/GBFPawnData.cpp
@@ -25,7 +25,11 @@ void UGBFPawnData::Serialize( FArchive & archive )
 
     if ( archive.CustomVer( FGBFPawnDataObjectVersion::GUID ) < FGBFPawnDataObjectVersion::MultipleInputConfigs )
     {
-        InputConfigs.AddUnique( InputConfig );
+        if ( InputConfig != nullptr )
+        {
+            InputConfigs.AddUnique( InputConfig );
+        }
+
         InputConfig = nullptr;
     }
 }

--- a/Source/GameBaseFramework/Private/GameFeatures/GBFGameFeatureAction_AddAbilities.cpp
+++ b/Source/GameBaseFramework/Private/GameFeatures/GBFGameFeatureAction_AddAbilities.cpp
@@ -14,6 +14,7 @@
 #define LOCTEXT_NAMESPACE "UGBFGameFeatureAction_AddAbilities"
 
 const FName UGBFGameFeatureAction_AddAbilities::NAME_AbilityReady( "AbilitiesReady" );
+const FName UGBFGameFeatureAction_AddAbilities::NAME_AbilityRemoved( "AbilitiesRemoved" );
 
 void UGBFGameFeatureAction_AddAbilities::OnGameFeatureActivating( FGameFeatureActivatingContext & context )
 {
@@ -199,7 +200,7 @@ void UGBFGameFeatureAction_AddAbilities::HandleActorExtension( AActor * actor, F
 
     const auto & entry = AbilitiesList[ entry_index ];
 
-    if ( event_name == UGameFrameworkComponentManager::NAME_ExtensionRemoved || event_name == UGameFrameworkComponentManager::NAME_ReceiverRemoved )
+    if ( event_name == UGameFrameworkComponentManager::NAME_ExtensionRemoved || event_name == UGameFrameworkComponentManager::NAME_ReceiverRemoved || event_name == UGBFGameFeatureAction_AddAbilities::NAME_AbilityRemoved )
     {
         RemoveActorAbilities( actor, *active_data );
     }

--- a/Source/GameBaseFramework/Private/GameFramework/GBFPlayerState.cpp
+++ b/Source/GameBaseFramework/Private/GameFramework/GBFPlayerState.cpp
@@ -71,18 +71,25 @@ void AGBFPlayerState::SetPawnData( const UGBFPawnData * new_pawn_data )
 
     if ( PawnData != nullptr )
     {
-        UE_LOG( LogGBF, Error, TEXT( "Trying to set PawnData [%s] on player state [%s] that already has valid PawnData [%s]." ), *GetNameSafe( new_pawn_data ), *GetNameSafe( this ), *GetNameSafe( PawnData ) );
-        return;
+        for ( auto & ability_handles : GrantedAbilities )
+        {
+            ability_handles.TakeFromAbilitySystem( AbilitySystemComponent );
+        }
+
+        UGameFrameworkComponentManager::SendGameFrameworkComponentExtensionEvent( this, UGBFGameFeatureAction_AddAbilities::NAME_AbilityRemoved );
+
+        GrantedAbilities.Reset();
     }
 
-    // MARK_PROPERTY_DIRTY_FROM_NAME( ThisClass, PawnData, this );
     PawnData = new_pawn_data;
+
+    GrantedAbilities.Reserve( PawnData->AbilitySets.Num() );
 
     for ( const auto & ability_set : PawnData->AbilitySets )
     {
         if ( ability_set != nullptr )
         {
-            ability_set->GiveToAbilitySystem( AbilitySystemComponent, nullptr );
+            ability_set->GiveToAbilitySystem( AbilitySystemComponent, &GrantedAbilities.AddDefaulted_GetRef() );
         }
     }
 

--- a/Source/GameBaseFramework/Public/Characters/GBFPawnData.h
+++ b/Source/GameBaseFramework/Public/Characters/GBFPawnData.h
@@ -61,11 +61,10 @@ public:
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Abilities" )
     TObjectPtr< UGBFAbilityTagRelationshipMapping > TagRelationshipMapping;
 
-    // Input configuration used by player controlled pawns to create input mappings and bind input actions.
-    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Input" )
+    UPROPERTY( meta = ( DeprecatedProperty, DeprecationMessage = "Use InputConfigs instead" ) )
     TObjectPtr< UGBFInputConfig > InputConfig;
 
-    // Input configuration used by player controlled pawns to create input mappings and bind input actions.
+    // Input configurations used by player controlled pawns to create input mappings and bind input actions.
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Input" )
     TArray< TObjectPtr< UGBFInputConfig > > InputConfigs;
 

--- a/Source/GameBaseFramework/Public/Characters/GBFPawnData.h
+++ b/Source/GameBaseFramework/Public/Characters/GBFPawnData.h
@@ -14,6 +14,25 @@ class UCameraModifier;
 class UGBFInputConfig;
 class UGBFCameraMode;
 
+struct GAMEBASEFRAMEWORK_API FGBFPawnDataObjectVersion
+{
+    enum Type
+    {
+        MultipleInputConfigs,
+
+        // -----<new versions can be added above this line>-------------------------------------------------
+        VersionPlusOne,
+        LatestVersion = VersionPlusOne - 1
+    };
+
+    // The GUID for this custom version number
+    const static FGuid GUID;
+
+private:
+    FGBFPawnDataObjectVersion()
+    {}
+};
+
 UCLASS()
 class GAMEBASEFRAMEWORK_API UGBFPawnData : public UPrimaryDataAsset
 {
@@ -23,6 +42,8 @@ public:
     UGBFPawnData();
 
     FPrimaryAssetId GetPrimaryAssetId() const override;
+
+    void Serialize( FArchive & archive ) override;
 
 #if WITH_EDITOR
     EDataValidationResult IsDataValid( FDataValidationContext & context ) const override;
@@ -43,6 +64,10 @@ public:
     // Input configuration used by player controlled pawns to create input mappings and bind input actions.
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Input" )
     TObjectPtr< UGBFInputConfig > InputConfig;
+
+    // Input configuration used by player controlled pawns to create input mappings and bind input actions.
+    UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Input" )
+    TArray< TObjectPtr< UGBFInputConfig > > InputConfigs;
 
     // Camera modifiers to add to the player camera manager
     UPROPERTY( EditDefaultsOnly, BlueprintReadOnly, Category = "Camera" )

--- a/Source/GameBaseFramework/Public/GameFeatures/GBFGameFeatureAction_AddAbilities.h
+++ b/Source/GameBaseFramework/Public/GameFeatures/GBFGameFeatureAction_AddAbilities.h
@@ -93,7 +93,9 @@ public:
     EDataValidationResult IsDataValid( FDataValidationContext & context ) const override;
 #endif
 
-    static const FName NAME_AbilityReady;
+    static const FName
+        NAME_AbilityReady,
+        NAME_AbilityRemoved;
 
 private:
     struct FActorExtensions

--- a/Source/GameBaseFramework/Public/GameFramework/GBFPlayerState.h
+++ b/Source/GameBaseFramework/Public/GameFramework/GBFPlayerState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GAS/Abilities/GBFAbilitySet.h"
 #include "GAS/Tags/GBFGameplayTagStack.h"
 
 #include <AbilitySystemInterface.h>
@@ -57,6 +58,7 @@ public:
         return Cast< T >( PawnData );
     }
 
+    UFUNCTION( BlueprintCallable )
     void SetPawnData( const UGBFPawnData * new_pawn_data );
 
     void PostInitializeComponents() override;
@@ -88,6 +90,7 @@ protected:
     const UGBFPawnData * PawnData;
 
     FString ConnectionOptions;
+    TArray< FGBFAbilitySet_GrantedHandles > GrantedAbilities;
 };
 
 FORCEINLINE UGBFAbilitySystemComponent * AGBFPlayerState::GetGBFAbilitySystemComponent() const


### PR DESCRIPTION
- Updated player state and pawn ext to allow to call SetPawnData and update GAS at the same time
- Added custom version serialization in GBFPawnData
- Can use multiple input configs in the pawn data
