### PR TITLE
Split action bar :  collect garbage when requesting update widget

### DIFF
--- a/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
+++ b/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
@@ -165,6 +165,8 @@ void UGBFSplitCommonBoundActionBar::HandleBoundActionsUpdated( bool from_owning_
     {
         bIsRefreshQueued = true;
     }
+
+    GEngine->ForceGarbageCollection();
 }
 
 void UGBFSplitCommonBoundActionBar::HandleDeferredDisplayUpdate()


### PR DESCRIPTION
If the garbage is not collected old/deleted action widgets still remain as input action till the garbage is collected