### PR TITLE
fix_actor_abilities_tags

### DIFF
--- a/Source/GameBaseFramework/Private/Characters/GBFSimpleCharacterWithAbilities.cpp
+++ b/Source/GameBaseFramework/Private/Characters/GBFSimpleCharacterWithAbilities.cpp
@@ -62,8 +62,8 @@ void AGBFSimpleCharacterWithAbilities::BeginPlay()
 
 void AGBFSimpleCharacterWithAbilities::GetOwnedGameplayTags( FGameplayTagContainer & tag_container ) const
 {
-    tag_container.AppendTags( StaticTags );
     AbilitySystemComponent->GetOwnedGameplayTags( tag_container );
+    tag_container.AppendTags( StaticTags );
 }
 
 void AGBFSimpleCharacterWithAbilities::OnMovementModeChanged( EMovementMode prev_movement_mode, uint8 previous_custom_mode )

--- a/Source/GameBaseFramework/Private/GAS/GBFActorWithAbilities.cpp
+++ b/Source/GameBaseFramework/Private/GAS/GBFActorWithAbilities.cpp
@@ -59,6 +59,6 @@ void AGBFActorWithAbilities::BeginPlay()
 
 void AGBFActorWithAbilities::GetOwnedGameplayTags( FGameplayTagContainer & tag_container ) const
 {
-    tag_container.AppendTags( StaticTags );
     AbilitySystemComponent->GetOwnedGameplayTags( tag_container );
+    tag_container.AppendTags( StaticTags );
 }


### PR DESCRIPTION
change function call order because `GetOwnedTags` reset the tag container