### PR TITLE
[Split Action Bar] Avoid display removed action

### DIFF
--- a/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
+++ b/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
@@ -206,6 +206,12 @@ void UGBFSplitCommonBoundActionBar::HandleDeferredDisplayUpdate()
             auto filtered_bindings = action_router->GatherActiveBindings().FilterByPredicate( [ action_router, player_input_type, player_gamepad_name, &accepted_bindings ]( const auto & handle ) mutable {
                 if ( auto binding = FUIActionBinding::FindBinding( handle ) )
                 {
+                    if ( binding->BoundWidget.Get()->GetParent() == nullptr )
+                    {
+                        auto key = binding->GetLegacyInputActionData()->GetInputTypeInfo( player_input_type, player_gamepad_name ).GetKey();
+                        return key == EKeys::Virtual_Back || key == EKeys::Escape || key == EKeys::Android_Back;
+                    }
+
                     if ( !binding->bDisplayInActionBar && !bSplitActionBarIgnoreOptOut )
                     {
                         return false;

--- a/Source/GameBaseFramework/Private/Phases/GBFGamePhaseSubsystem.cpp
+++ b/Source/GameBaseFramework/Private/Phases/GBFGamePhaseSubsystem.cpp
@@ -334,7 +334,7 @@ void UGBFGamePhaseSubsystem::EndAllPhases()
     auto * game_state_asc = world->GetGameState()->FindComponentByClass< UGBFAbilitySystemComponent >();
 
     for ( auto copy = ActivePhaseMap;
-         auto & item : copy )
+          auto & item : copy )
     {
         game_state_asc->CancelAbilitiesByFunc( [ &item ]( const UGBFGameplayAbility * ability, FGameplayAbilitySpecHandle handle ) {
             return handle == item.Key;


### PR DESCRIPTION
Check if the binding has a valid parent to avoid removed action but not yet garbage collected to be displayed. 

Since back actions can be on the top parent widget ( back handler property on activatables for exemple ), we need to check that too to know if the actions needs to be displayed or not.