### PR TITLE
Split Action Bar : Added action exlusion list

### DIFF
--- a/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
+++ b/Source/GameBaseFramework/Private/GBFSplitCommonBoundActionBar.cpp
@@ -27,7 +27,6 @@ static FAutoConsoleVariableRef CVarSplitActionBarIgnoreOptOut(
 
 UGBFSplitCommonBoundActionBar::UGBFSplitCommonBoundActionBar( const FObjectInitializer & object_initializer ) :
     Super( object_initializer ),
-    bHideDefaultAcceptAction( false ),
     WidgetPool( *this )
 {
 }
@@ -368,7 +367,7 @@ void UGBFSplitCommonBoundActionBar::HandleDeferredDisplayUpdate()
                         is_back_action = key == EKeys::Virtual_Back || key == EKeys::Escape || key == EKeys::Android_Back;
                     }
 
-                    if ( key == EKeys::Virtual_Accept && bHideDefaultAcceptAction )
+                    if ( ActionExclusionList.Contains( binding->LegacyActionTableRow ) )
                     {
                         continue;
                     }

--- a/Source/GameBaseFramework/Public/GBFSplitCommonBoundActionBar.h
+++ b/Source/GameBaseFramework/Public/GBFSplitCommonBoundActionBar.h
@@ -54,9 +54,6 @@ private:
     UPROPERTY( EditAnywhere, Category = EntryLayout, meta = ( MustImplement = "/Script/CommonUI.CommonBoundActionButtonInterface" ) )
     TSubclassOf< UGBFBoundActionButton > ActionButtonClass;
 
-    UPROPERTY( EditAnywhere, Category = Display, meta = ( AllowPrivateAccess ) )
-    uint8 bHideDefaultAcceptAction : 1;
-
     UPROPERTY( EditAnywhere, Category = Display )
     uint8 bDisplayOwningPlayerActionsOnly : 1;
 
@@ -65,6 +62,9 @@ private:
 
     UPROPERTY( BlueprintReadOnly, meta = ( AllowPrivateAccess, BindWidget ) )
     TObjectPtr< UPanelWidget > ActionButtonsContainer;
+
+    UPROPERTY( EditAnywhere, Category = Display, meta = ( AllowPrivateAccess ) )
+    TArray< FDataTableRowHandle > ActionExclusionList;
 
     UPROPERTY( Transient )
     FUserWidgetPool WidgetPool;


### PR DESCRIPTION
Earlier, I added the option to not display the generic accept key but the problem was we cant then display an other action using that key. changing that boolean to a list of action to exclude fix the problem and allow even more control