### PR TITLE
Camera modifier jump improvements

### DIFF
--- a/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
+++ b/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
@@ -6,15 +6,11 @@
 
 UGBFCameraModifierJumpZ::UGBFCameraModifierJumpZ() :
     LandingTransitionTime( 0.5f ),
-    LandOnSameHeightCheckTolerance( 1.0f ),
     DistanceFromLastGroundedPositionToResetModifier( 50.0f ),
     CurrentState( EState::WaitingForJump ),
     LastGroundedCameraZPosition( 0.0f ),
     LastGroundedCharacterZPosition( 0.0f ),
-    DeltaLastGroundedCharacterToCameraZ( 0.0f ),
     CurrentCharacterZPosition( 0.0f ),
-    CurrentCameraZPosition( 0.0f ),
-    LerpStartCameraZPosition( 0.0f ),
     LerpEndCameraZPosition( 0.0f ),
     LandingTransitionRemainingTime( 0.0f )
 {
@@ -42,6 +38,11 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
     if ( cmc == nullptr )
     {
         return;
+    }
+
+    if ( !CurrentCameraZPosition.IsSet() )
+    {
+        CurrentCameraZPosition = view_location.Z;
     }
 
     CurrentCharacterZPosition = character->GetActorLocation().Z;
@@ -82,7 +83,7 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
                  FMath::Abs( CurrentCharacterZPosition - LastGroundedCharacterZPosition ) < DistanceFromLastGroundedPositionToResetModifier )
             {
                 LastGroundedCharacterZPosition = CurrentCharacterZPosition;
-                LastGroundedCameraZPosition = CurrentCameraZPosition;
+                LastGroundedCameraZPosition = CurrentCameraZPosition.GetValue();
 
                 CurrentState = EState::Jumping;
                 break;
@@ -106,10 +107,10 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
     {
         case EState::WaitingForJump:
         {
-            LastGroundedCameraZPosition = CurrentCameraZPosition;
+            LastGroundedCameraZPosition = CurrentCameraZPosition.GetValue();
             LastGroundedCharacterZPosition = CurrentCharacterZPosition;
 
-            new_view_location.Z = FMath::FInterpTo( CurrentCameraZPosition, view_location.Z, delta_time, 10.0f );
+            new_view_location.Z = FMath::FInterpTo( CurrentCameraZPosition.GetValue(), view_location.Z, delta_time, 10.0f );
         }
         break;
         case EState::Jumping:
@@ -152,22 +153,21 @@ void UGBFCameraModifierJumpZ::DisplayDebugInternal( UCanvas * canvas, const FDeb
         {
             display_debug_manager.DrawString( TEXT( "State : Waiting For Jump" ) );
             display_debug_manager.DrawString( FString::Printf( TEXT( "LastGroundedCameraZPosition: %s" ), *FString::SanitizeFloat( LastGroundedCameraZPosition ) ) );
-            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition ) ) );
+            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition.GetValue() ) ) );
         }
         break;
         case EState::Jumping:
         {
             display_debug_manager.DrawString( TEXT( "State : Jumping" ) );
             display_debug_manager.DrawString( FString::Printf( TEXT( "LastGroundedCameraZPosition: %s" ), *FString::SanitizeFloat( LastGroundedCameraZPosition ) ) );
-            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition ) ) );
+            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition.GetValue() ) ) );
         }
         break;
         case EState::Landing:
         {
             display_debug_manager.DrawString( TEXT( "State : Landing" ) );
             display_debug_manager.DrawString( FString::Printf( TEXT( "LandingTransitionRemainingTime: %s" ), *FString::SanitizeFloat( LandingTransitionRemainingTime ) ) );
-            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition ) ) );
-            display_debug_manager.DrawString( FString::Printf( TEXT( "LerpStartCameraZPosition: %s" ), *FString::SanitizeFloat( LerpStartCameraZPosition ) ) );
+            display_debug_manager.DrawString( FString::Printf( TEXT( "CurrentCameraZPosition: %s" ), *FString::SanitizeFloat( CurrentCameraZPosition.GetValue() ) ) );
             display_debug_manager.DrawString( FString::Printf( TEXT( "LerpEndCameraZPosition: %s" ), *FString::SanitizeFloat( LerpEndCameraZPosition ) ) );
         }
         break;

--- a/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
+++ b/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
@@ -78,7 +78,8 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
         break;
         case EState::Landing:
         {
-            if ( character->bWasJumping )
+            if ( character->bWasJumping &&
+                 FMath::Abs( CurrentCharacterZPosition - LastGroundedCharacterZPosition ) < DistanceFromLastGroundedPositionToResetModifier )
             {
                 LastGroundedCharacterZPosition = CurrentCharacterZPosition;
                 LastGroundedCameraZPosition = CurrentCameraZPosition;
@@ -89,6 +90,7 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
 
             if ( LandingTransitionRemainingTime <= 0.0f )
             {
+
                 CurrentState = EState::WaitingForJump;
                 break;
             }
@@ -106,6 +108,8 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
         {
             LastGroundedCameraZPosition = CurrentCameraZPosition;
             LastGroundedCharacterZPosition = CurrentCharacterZPosition;
+
+            new_view_location.Z = FMath::FInterpTo( CurrentCameraZPosition, view_location.Z, delta_time, 10.0f );
         }
         break;
         case EState::Jumping:
@@ -117,7 +121,16 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
         {
             LandingTransitionRemainingTime -= delta_time;
 
-            new_view_location.Z = FMath::Lerp( LastGroundedCameraZPosition, view_location.Z, 1.0f - ( LandingTransitionRemainingTime / LandingTransitionTime ) );
+            if ( FMath::Abs( LastGroundedCharacterZPosition - CurrentCharacterZPosition ) <= DistanceFromLastGroundedPositionToResetModifier )
+            {
+                LerpEndCameraZPosition = LastGroundedCameraZPosition;
+            }
+            else
+            {
+                LerpEndCameraZPosition = view_location.Z;
+            }
+
+            new_view_location.Z = FMath::Lerp( LastGroundedCameraZPosition, LerpEndCameraZPosition, 1.0f - ( LandingTransitionRemainingTime / LandingTransitionTime ) );
         }
         break;
         default:

--- a/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
+++ b/Source/GameBaseFramework/Private/Camera/Modifiers/GBFCameraModifierJumpZ.cpp
@@ -7,6 +7,7 @@
 UGBFCameraModifierJumpZ::UGBFCameraModifierJumpZ() :
     LandingTransitionTime( 0.5f ),
     DistanceFromLastGroundedPositionToResetModifier( 50.0f ),
+    DefaultInterpolationSpeed( 10.0f ),
     CurrentState( EState::WaitingForJump ),
     LastGroundedCameraZPosition( 0.0f ),
     LastGroundedCharacterZPosition( 0.0f ),
@@ -110,7 +111,7 @@ void UGBFCameraModifierJumpZ::ModifyCamera( const float delta_time, const FVecto
             LastGroundedCameraZPosition = CurrentCameraZPosition.GetValue();
             LastGroundedCharacterZPosition = CurrentCharacterZPosition;
 
-            new_view_location.Z = FMath::FInterpTo( CurrentCameraZPosition.GetValue(), view_location.Z, delta_time, 10.0f );
+            new_view_location.Z = FMath::FInterpTo( CurrentCameraZPosition.GetValue(), view_location.Z, delta_time, DefaultInterpolationSpeed );
         }
         break;
         case EState::Jumping:

--- a/Source/GameBaseFramework/Public/Camera/Modifiers/GBFCameraModifierJumpZ.h
+++ b/Source/GameBaseFramework/Public/Camera/Modifiers/GBFCameraModifierJumpZ.h
@@ -39,6 +39,10 @@ private:
     UPROPERTY( EditAnywhere )
     float DistanceFromLastGroundedPositionToResetModifier;
 
+    // When waiting for a jump, how fast do we interpolate to the camera view
+    UPROPERTY( EditAnywhere )
+    float DefaultInterpolationSpeed;
+
     EState CurrentState;
     float LastGroundedCameraZPosition;
     float LastGroundedCharacterZPosition;

--- a/Source/GameBaseFramework/Public/Camera/Modifiers/GBFCameraModifierJumpZ.h
+++ b/Source/GameBaseFramework/Public/Camera/Modifiers/GBFCameraModifierJumpZ.h
@@ -35,10 +35,6 @@ private:
     UPROPERTY( EditAnywhere )
     float LandingTransitionTime;
 
-    // Tolerance when comparing the character location on Z when he lands versus when he jumped
-    UPROPERTY( EditAnywhere )
-    float LandOnSameHeightCheckTolerance;
-
     // When falling after jumping, when the character goes below his last grounded position minus this property, we stop the modifier
     UPROPERTY( EditAnywhere )
     float DistanceFromLastGroundedPositionToResetModifier;
@@ -46,10 +42,8 @@ private:
     EState CurrentState;
     float LastGroundedCameraZPosition;
     float LastGroundedCharacterZPosition;
-    float DeltaLastGroundedCharacterToCameraZ;
     float CurrentCharacterZPosition;
-    float CurrentCameraZPosition;
-    float LerpStartCameraZPosition;
+    TOptional< float > CurrentCameraZPosition;
     float LerpEndCameraZPosition;
     float LandingTransitionRemainingTime;
 };


### PR DESCRIPTION
Additional improvements:
- Prevent first camera frame from going under the ground
- Removes some more jittering that can occur